### PR TITLE
collectBlocks() refactor

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -119,49 +119,46 @@ function parseNode(node) {
 
 function collectBlocks(node) {
     if (!node.children) return node;
+    
     var newChildren = [];
-    var blocks = [];
-    var targetBlock;
+    var blockStack = [];
 
-    node.children.forEach(function (child) {
+    node.children.forEach(function (node) {
         var block;
 
-        if (child.type === 'BlockStart') {
-            block = AST.BlockStatement(child.blockType, child.blockExpression);
+        if (node.type === 'BlockStart') {
+            block = AST.BlockStatement(node.blockType, node.blockExpression);
             block.state = 'body';
-
-            blocks.push(block);
-            return;
+            blockStack.push(block);
         }
-
-        if (child.type === 'BlockElse') {
-            blocks[blocks.length - 1].state = 'alternate';
-            return;
+        else if (node.type === 'BlockElse') {
+            last(blockStack).state = 'alternate';
         }
-
-        if (child.type === 'BlockEnd') {
-            block = blocks.pop();
-            delete block.state;
-
-            if (blocks.length > 0) {
-                targetBlock = blocks[blocks.length - 1];
-                targetBlock[targetBlock.state].push(block);
-            } else {
-                newChildren.push(block);
+        else {
+            if (node.type === 'BlockEnd') {
+                node = blockStack.pop();
+                delete node.state;
             }
-            return;
-        }
 
-        if (blocks[blocks.length - 1]) {
-            block = blocks[blocks.length - 1];
-            block[block.state].push(child);
-        } else {
-            newChildren.push(child);
+            var currentNodeList;
+            if (blockStack.length) {
+                block = last(blockStack);
+                currentNodeList = block[block.state];
+            }
+            else {
+                currentNodeList = newChildren;
+            }
+
+            currentNodeList.push(node);
         }
     });
 
     node.children = newChildren.map(collectBlocks);
     return node;
+}
+
+function last(arr) {
+    return arr[arr.length - 1];
 }
 
 


### PR DESCRIPTION
@latentflip: I tried my hand at a `collectBlocks()` refactor. I tried to keep the style consistent w/ the rest of the project, but feel free to adjust if anything looks unnatural.

I wasn't sure if it was worth it to include underscore just to get `_.last()` so I defined a `last()` function... a lot of times I'll just use the `arr[arr.length - 1` idiom, but since it was there a couple times, I figured it might be cleaner to use `last()`...

I renamed `child` to `node` -- usually I would prefer the more specific `child`, but I wanted to consolidate and handle `block` and `child` together (pushing to `currentNodeList`), so I figured the more generic `node` was more appropriate...

Feel free to modify anything (including the things mentioned above) as suits your taste.

Thanks for writing domthing & contributing it to the open-source community!
