### PR TITLE
Should be able to access an element's template

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -170,6 +170,7 @@ module.exports.compile = function (ast, o) {
 
     var postlude = [
         indent(o.depth + 1, "var firstChild = template.html.firstChild;"),
+        indent(o.depth + 1, "firstChild.template = template;"),
         indent(o.depth + 1, "firstChild.update = template.update.bind(template);"),
         indent(o.depth + 1, "return firstChild;"),
         indent(o.depth, "}")


### PR DESCRIPTION
I'm trying to add automatic bindings to [bacon.model](https://github.com/baconjs/bacon.model), and I need to have access to the internal template state. Nut sure if there's a nicer way of doing it than just sticking `template` on the element.
