### PR TITLE
Fix block nesting

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -187,6 +187,8 @@ function collectBlocks(node) {
         else {
             if (node.type === 'BlockEnd') {
                 node = blockStack.pop();
+                node.body = node.body.map(collectBlocks);
+                node.alternate = node.alternate.map(collectBlocks);
                 delete node.state;
             }
 

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -236,11 +236,13 @@ test('handles blocks in text', function (t) {
 test('parses nested if/else statements', function (t) {
     var tmpl = [
         "{{#if foo }}",
-        "    {{#if bar }}",
-        "        <a></a>",
-        "    {{#else }}",
-        "        <c></c>",
-        "   {{/if}}",
+        "    <div>",
+        "        {{#if bar }}",
+        "            <a></a>",
+        "        {{#else }}",
+        "            <c></c>",
+        "        {{/if}}",
+        "    </div>",
         "{{#else }}",
         "    <b></b>",
         "{{/if}}",
@@ -249,13 +251,17 @@ test('parses nested if/else statements', function (t) {
     t.astEqual(tmpl, AST.Template([
         AST.BlockStatement('if', AST.Binding('foo'), [
             AST.TextNode(AST.Literal(' ')),
-            AST.BlockStatement('if', AST.Binding('bar'), [
+            AST.Element('div', [
                 AST.TextNode(AST.Literal(' ')),
-                AST.Element('a'),
-                AST.TextNode(AST.Literal(' ')),
-            ], [
-                AST.TextNode(AST.Literal(' ')),
-                AST.Element('c'),
+                AST.BlockStatement('if', AST.Binding('bar'), [
+                    AST.TextNode(AST.Literal(' ')),
+                    AST.Element('a'),
+                    AST.TextNode(AST.Literal(' ')),
+                ], [
+                    AST.TextNode(AST.Literal(' ')),
+                    AST.Element('c'),
+                    AST.TextNode(AST.Literal(' ')),
+                ]),
                 AST.TextNode(AST.Literal(' ')),
             ]),
             AST.TextNode(AST.Literal(' ')),


### PR DESCRIPTION
Blocks nested inside an element inside a block where not parsed properly. That is fixed by also running `collectBlocks` on the `body` and `alternate`.
The according test is updated to use this nested case.
